### PR TITLE
fix: Update default page size in SuppliersManagement component

### DIFF
--- a/src/components/SuppliersManagement.tsx
+++ b/src/components/SuppliersManagement.tsx
@@ -82,7 +82,7 @@ const SuppliersManagement = () => {
     setPageSize,
     viewMode,
     setViewMode,
-  } = usePersistedListUiState("contactos/lista", { defaultPageSize: 18, defaultView: "cards" });
+  } = usePersistedListUiState("contactos/lista", { defaultPageSize: 20, defaultView: "cards" });
   const [partyFilter, setPartyFilter] = useState<"all" | "SUPPLIER" | "CUSTOMER">("all");
   const [selectedSupplier, setSelectedSupplier] = useState<Supplier | null>(null);
   const [isImportOpen, setIsImportOpen] = useState(false);


### PR DESCRIPTION
- Changed the default page size from 18 to 20 in the usePersistedListUiState hook for improved user experience in supplier management.